### PR TITLE
Compile on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ project(apriltag_mit VERSION 1.0.0 LANGUAGES CXX)
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+add_compile_definitions(_USE_MATH_DEFINES)
+
 # set(CMAKE_CXX_CLANG_TIDY clang-tidy)
 
 find_package(Eigen3 REQUIRED)

--- a/src/TagFamily.cc
+++ b/src/TagFamily.cc
@@ -102,6 +102,13 @@ code_t Rotate90DegCwise(code_t w, int d) {
   return wr;
 }
 
+#ifdef _MSC_VER
+#  include <intrin.h> 
+unsigned __builtin_popcountll( unsigned long long data){
+  return __popcnt(data) + __popcnt(data >> 32);
+}
+#endif
+
 unsigned HammingDistance(code_t a, code_t b) {
   // Because code_t is unsigned long long
   return __builtin_popcountll(a ^ b);


### PR DESCRIPTION
As part of https://github.com/ros-misc-utilities/apriltag_detector/issues/6

I made similar changes here. Note, windows doesn't provide a 64 bit count bits function, so I sloppily implemented one myself. Here is test result detecting the apriltag image in the detector package. 

MIT
![mit](https://github.com/user-attachments/assets/1914fb37-24c3-4c05-bc35-76f90db4ccec)

Umich
![umich](https://github.com/user-attachments/assets/d8ac32a9-132c-4165-af16-867ed9bb6070)

The apriltag library inside apriltag_mit declares but never defines a PopCount function which is really probably the right place for this code ... 


https://github.com/ros-misc-utilities/apriltag_mit/blob/master/include/apriltag_mit/AprilTags/TagFamily.h#L88


